### PR TITLE
fix: make CMS deps optional in getState resolver

### DIFF
--- a/src/Forms/Components/Uploadcare.php
+++ b/src/Forms/Components/Uploadcare.php
@@ -344,7 +344,11 @@ class Uploadcare extends Field
         $items = $wasList ? $state : [$state];
 
         // Resolve Backstage Media ULIDs or Models into Uploadcare rich objects.
-        $resolved = self::resolveUlidsToUploadcareState($items, $this->getRecord(), $this->getFieldUlid());
+        // This resolution requires the optional backstage/media + backstage/uploadcare-field
+        // packages. When they are absent (standalone usage), pass items through unchanged.
+        $resolved = (class_exists(Media::class) && class_exists(Factory::class))
+            ? self::resolveUlidsToUploadcareState($items, $this->getRecord(), $this->getFieldUlid())
+            : $items;
 
         // Transform URLs from database format back to ucarecdn.com format for the widget
         if ($this->shouldTransformUrlsForDb()) {


### PR DESCRIPTION
## Summary

The `getState()` resolver hard-references `Backstage\Media\Models\Media` and `Backstage\UploadcareField\Uploadcare` (Factory). Both live in separate packages that are not declared as requires of this package, so installing it standalone (state = plain CDN URLs) crashes with `Class "Backstage\Media\Models\Media" not found` the moment the field is rendered.

This PR guards the resolver call with `class_exists()` checks. When the CMS packages are absent, items pass through unchanged — matching v1.x behaviour for non-CMS consumers.

## Test plan
- [ ] Install in a standalone Filament v4 app with plain CDN URLs as state — verify the field renders without `Class not found`.
- [ ] Install in a Backstage CMS app (Media + UploadcareField installed) — verify ULID-to-rich-object resolution still works.
- [ ] Verify save / upload / delete flows in both scenarios.